### PR TITLE
#33990 - Skip flaky Redis tests.

### DIFF
--- a/src/tests/Metalama.Patterns.Caching.UnitTests/Backends/Single/LocallyCachedRedisCacheBackendTests.cs
+++ b/src/tests/Metalama.Patterns.Caching.UnitTests/Backends/Single/LocallyCachedRedisCacheBackendTests.cs
@@ -1,16 +1,24 @@
 ﻿// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
+using Xunit;
+
+namespace Metalama.Patterns.Caching.Tests.Backends.Single;
+
+#if !ENABLE_FLAKY_REDIS_TESTS
+public class LocallyCachedRedisCacheBackendTests
+{
+    [Fact( Skip = "#33990: Skipping all tests in class LocallyCachedRedisCacheBackendTests" )]
+    public void PlaceholderForInheritedTestsInCommonBaseClass()
+    { }
+}
+#else
 using Metalama.Patterns.Caching.Aspects;
 using Metalama.Patterns.Caching.Backends;
 using Metalama.Patterns.Caching.Backends.Redis;
 using Metalama.Patterns.Caching.Implementation;
 using Metalama.Patterns.Caching.TestHelpers;
 using Metalama.Patterns.Caching.Tests.Backends.Distributed;
-using Xunit;
 using Xunit.Abstractions;
-
-namespace Metalama.Patterns.Caching.Tests.Backends.Single;
-
 public class LocallyCachedRedisCacheBackendTests : BaseCacheBackendTests, IAssemblyFixture<RedisSetupFixture>
 {
     private readonly RedisSetupFixture _redisSetupFixture;
@@ -130,3 +138,4 @@ public class LocallyCachedRedisCacheBackendTests : BaseCacheBackendTests, IAssem
     [Fact( Skip = "https://postsharp.tpondemand.com/entity/33937-test-locallycachedrediscachebackendteststestremovaleventbydependencyasync-is-flaky" )]
     public override Task TestRemovalEventByDependencyAsync() => base.TestRemovalEventByDependencyAsync();
 }
+#endif

--- a/src/tests/Metalama.Patterns.Caching.UnitTests/Backends/Single/LocallyCachedRedisCacheBackendWithGarbageCollectorTests.cs
+++ b/src/tests/Metalama.Patterns.Caching.UnitTests/Backends/Single/LocallyCachedRedisCacheBackendWithGarbageCollectorTests.cs
@@ -1,10 +1,19 @@
 // Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
-using Metalama.Patterns.Caching.TestHelpers;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Metalama.Patterns.Caching.Tests.Backends.Single;
 
+#if !ENABLE_FLAKY_REDIS_TESTS
+public class LocallyCachedRedisCacheBackendWithGarbageCollectorTests
+{
+    [Fact( Skip = "#33990: Skipping all tests in class LocallyCachedRedisCacheBackendWithGarbageCollectorTests" )]
+    public void PlaceholderForInheritedTestsInCommonBaseClass()
+    { }
+}
+#else
+using Metalama.Patterns.Caching.TestHelpers;
+using Xunit.Abstractions;
 public class LocallyCachedRedisCacheBackendWithGarbageCollectorTests : LocallyCachedRedisCacheBackendTests
 {
     public LocallyCachedRedisCacheBackendWithGarbageCollectorTests(
@@ -14,3 +23,4 @@ public class LocallyCachedRedisCacheBackendWithGarbageCollectorTests : LocallyCa
 
     protected override bool EnableGarbageCollector => true;
 }
+#endif

--- a/src/tests/Metalama.Patterns.Caching.UnitTests/Backends/Single/RedisCacheBackendTests.cs
+++ b/src/tests/Metalama.Patterns.Caching.UnitTests/Backends/Single/RedisCacheBackendTests.cs
@@ -1,16 +1,24 @@
 ﻿// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
+using Xunit;
+
+namespace Metalama.Patterns.Caching.Tests.Backends.Single;
+
+#if !ENABLE_FLAKY_REDIS_TESTS
+public class RedisCacheBackendTests
+{
+    [Fact( Skip = "#33990: Skipping all tests in class RedisCacheBackendTests" )]
+    public void PlaceholderForInheritedTestsInCommonBaseClass()
+    { }
+}
+#else
 using Metalama.Patterns.Caching.Backends.Redis;
 using Metalama.Patterns.Caching.Implementation;
 using Metalama.Patterns.Caching.TestHelpers;
 using Metalama.Patterns.Caching.Tests.Backends.Distributed;
 using StackExchange.Redis;
 using System.Collections.Immutable;
-using Xunit;
 using Xunit.Abstractions;
-
-namespace Metalama.Patterns.Caching.Tests.Backends.Single;
-
 public class RedisCacheBackendTests : BaseCacheBackendTests, IAssemblyFixture<RedisSetupFixture>
 {
     private readonly RedisSetupFixture _redisSetupFixture;
@@ -191,3 +199,4 @@ public class RedisCacheBackendTests : BaseCacheBackendTests, IAssemblyFixture<Re
         }
     }
 }
+#endif

--- a/src/tests/Metalama.Patterns.Caching.UnitTests/Backends/Single/RedisCacheBackendWithGarbageCollectorTests.cs
+++ b/src/tests/Metalama.Patterns.Caching.UnitTests/Backends/Single/RedisCacheBackendWithGarbageCollectorTests.cs
@@ -1,14 +1,22 @@
 // Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
+using Xunit;
+
+namespace Metalama.Patterns.Caching.Tests.Backends.Single;
+
+#if !ENABLE_FLAKY_REDIS_TESTS
+public class RedisCacheBackendWithGarbageCollectorTests
+{
+    [Fact( Skip = "#33990: Skipping all tests in class RedisCacheBackendWithGarbageCollectorTests" )]
+    public void PlaceholderForInheritedTestsInCommonBaseClass()
+    { }
+}
+#else
 using Metalama.Patterns.Caching.Backends.Redis;
 using Metalama.Patterns.Caching.Implementation;
 using Metalama.Patterns.Caching.TestHelpers;
 using System.Collections.Immutable;
-using Xunit;
 using Xunit.Abstractions;
-
-namespace Metalama.Patterns.Caching.Tests.Backends.Single;
-
 public sealed class RedisCacheBackendWithGarbageCollectorTests : RedisCacheBackendTests
 {
     public RedisCacheBackendWithGarbageCollectorTests(
@@ -166,3 +174,4 @@ public sealed class RedisCacheBackendWithGarbageCollectorTests : RedisCacheBacke
         }
     }
 }
+#endif

--- a/src/tests/Metalama.Patterns.Caching.UnitTests/Backends/Single/SimpleRedisCacheBackendTests.cs
+++ b/src/tests/Metalama.Patterns.Caching.UnitTests/Backends/Single/SimpleRedisCacheBackendTests.cs
@@ -1,13 +1,21 @@
 ﻿// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
-using Metalama.Patterns.Caching.Backends.Redis;
-using Metalama.Patterns.Caching.TestHelpers;
-using Metalama.Patterns.Caching.Tests.Backends.Distributed;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Metalama.Patterns.Caching.Tests.Backends.Single;
 
+#if !ENABLE_FLAKY_REDIS_TESTS
+public class SimpleRedisCacheBackendTests
+{
+    [Fact( Skip = "#33990: Skipping all tests in class SimpleRedisCacheBackendTests" )]
+    public void PlaceholderForInheritedTestsInCommonBaseClass()
+    { }
+}
+#else
+using Metalama.Patterns.Caching.Backends.Redis;
+using Metalama.Patterns.Caching.TestHelpers;
+using Metalama.Patterns.Caching.Tests.Backends.Distributed;
+using Xunit.Abstractions;
 // ReSharper disable once UnusedType.Global
 public class SimpleRedisCacheBackendTests : BaseCacheBackendTests, IAssemblyFixture<RedisSetupFixture>
 {
@@ -44,3 +52,4 @@ public class SimpleRedisCacheBackendTests : BaseCacheBackendTests, IAssemblyFixt
             await RedisFactory.CreateBackendAsync( this.TestOptions, this._redisSetupFixture, keyPrefix, serviceProvider: this.ServiceProvider ) );
     }
 }
+#endif


### PR DESCRIPTION
Because the actual tests are defined in a common base class for which some derived types have passing tests, the affected test classes have been #if'd out and replaced by a placeholder class with a single skipped test so that there is some indication that tests are being skipped.